### PR TITLE
Use socket `.send()` instead of `.sendto()` for already connected socket

### DIFF
--- a/src/network/dtls.py
+++ b/src/network/dtls.py
@@ -222,7 +222,10 @@ class Dtls:
                     self._buffer.receive_from_network(data)
                 except WantWriteError as exc:
                     in_transit = self._buffer.peek_outgoing(TLSWrappedSocket.CHUNK_SIZE)
-                    amt = self._socket.send(in_transit, flags)
+                    if address is None:
+                        amt = self._socket.send(in_transit, flags)
+                    else:
+                        amt = self._socket.sendto(in_transit, flags, address)
                     self._buffer.consume_outgoing(amt)
 
                     self._handshake_retries += 1
@@ -231,7 +234,10 @@ class Dtls:
                     if self._handshake_retries < 3:
                         logging.debug("Resending ClientHello")
                         time.sleep(0.3)
-                        amt = self._socket.send(in_transit, flags)
+                        if address is None:
+                            amt = self._socket.send(in_transit, flags)
+                        else:
+                            amt = self._socket.sendto(in_transit, flags, address)
                         self._buffer.consume_outgoing(amt)
 
                     if self._handshake_retries > 3:

--- a/src/network/dtls.py
+++ b/src/network/dtls.py
@@ -222,10 +222,7 @@ class Dtls:
                     self._buffer.receive_from_network(data)
                 except WantWriteError as exc:
                     in_transit = self._buffer.peek_outgoing(TLSWrappedSocket.CHUNK_SIZE)
-                    if address is None:
-                        amt = self._socket.send(in_transit, flags)
-                    else:
-                        amt = self._socket.sendto(in_transit, flags, address)
+                    amt = self._socket.send(in_transit, flags)
                     self._buffer.consume_outgoing(amt)
 
                     self._handshake_retries += 1
@@ -234,10 +231,7 @@ class Dtls:
                     if self._handshake_retries < 3:
                         logging.debug("Resending ClientHello")
                         time.sleep(0.3)
-                        if address is None:
-                            amt = self._socket.send(in_transit, flags)
-                        else:
-                            amt = self._socket.sendto(in_transit, flags, address)
+                        amt = self._socket.send(in_transit, flags)
                         self._buffer.consume_outgoing(amt)
 
                     if self._handshake_retries > 3:

--- a/src/services/streaming_service.py
+++ b/src/services/streaming_service.py
@@ -226,8 +226,8 @@ class StreamingService:
 
         while self._is_connection_alive:
             try:
-                self._dtls_service.get_socket().sendto(
-                    self._last_message, self._dtls_service.get_server_address()
+                self._dtls_service.get_socket().send(
+                    self._last_message
                 )
             except SocketError as e:
                 logging.error("Connection lost: %s", e)
@@ -327,12 +327,8 @@ class StreamingService:
             self._channel_data = self._pack_color_data(color, value)
             message = self._build_message(self._channel_data)
             logging.debug(message)
-            self._dtls_service.get_socket().sendto(
-                message,
-                (
-                    self._dtls_service.get_server_address()[0],
-                    self._dtls_service.get_server_address()[1],
-                ),
+            self._dtls_service.get_socket().send(
+                message
             )
             self._last_message = message
         except SocketError as e:


### PR DESCRIPTION
This PR resolves #24  where an already connected socket can not connect again. Which could be a macOS specific issue probably.

The `socket.sendto(..., address)`  tries to connect, while `socket` is already initialized in `dtls.py` at:

```python
dtls_client = ClientContext(config)
udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
udp_socket.settimeout(self._sock_timeout)
udp_socket.connect(self._server_address)
```

By replacing `socket.sendto(..., address)` with `socket.send(...)` it doesn't throw exceptions.

---

While this solves the problem for me, I'm not sure if this change is desirable. I have no background in networking, nor the knowledge of how these socket connections should be used the correct way.

If this could be the start of a solution. More code needs to refactored. Determine if a custom `address` argument is still needed or not.